### PR TITLE
fix(ModuleUtils): Guard setMDCAdapter call to prevent NoSuchMethodError on Android

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/utils/ModuleUtils.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/utils/ModuleUtils.java
@@ -231,7 +231,20 @@ public class ModuleUtils
         {
             LoggerContext logContext = new LoggerContext();
             logContext.setName(FileUtils.safeFileName(moduleID));
-            logContext.setMDCAdapter(new LogbackMDCAdapter());
+            try
+            {
+                logContext.setMDCAdapter(new LogbackMDCAdapter());
+            }
+            catch (NoSuchMethodError e)
+            {
+                /*
+                * The logback-android 3.0.0 ships 1.4.x classes, which is why a call compiled against 1.5.13 finds nothing. 
+                * The new 1.5 method, setMDCAdapter, will never resolve during runtime.
+                * The saved 1.4.x info used at runtime is still accessible thus we can skip the setMDCAdapter method.
+                * Once the latest logback-android project incorporates a 1.5.x release, this exception handling bracket can be removed.
+                */
+                log.debug("The logback-android 3.0.0 ships 1.4.x classes. Bypassing a 1.5.x setMDCAdapter method will allow the old tech to exist.");
+            }
             logContext.putProperty(LOG_MODULE_ID, FileUtils.safeFileName(moduleID));
             logContext.putProperty(LOG_MODULE_NAME, module.getName());
             new ContextInitializer(logContext).autoConfig();


### PR DESCRIPTION
`ModuleUtils.createModuleLogger()` throws `NoSuchMethodError` on Android, which kills
module init — the ConSys client module fails to start on every app launch.

osh-core compiles against logback-classic 1.5.13, which added
`LoggerContext.setMDCAdapter()` (0c5671053). Android builds exclude real Logback and
substitute logback-android 3.0.0, built from the Logback 1.4.x generation, where that
method doesn't exist. Desktop nodes are unaffected.

Wraps the call in a `NoSuchMethodError` guard. Logback wired MDC globally before 1.5, so
skipping it restores the earlier behavior rather than dropping functionality. The guard
can be removed once logback-android ships a 1.5-based release.

Verified on an Android emulator: system registers and streams datastreams to a node.